### PR TITLE
Add split/save/restore commands and line trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ print(sess[-20:])                     # last 20 lines of buffer
 
 ```bash
 ptmux list            # show all tmux session names
-ptmux attach build    # shortcut for: tmux attach -t build
+ptmux attach NAME     # shortcut for: tmux attach -t NAME
+ptmux split [u|d|l|r] [size]   # split current pane
+ptmux save NAME       # save current tmux layout
+ptmux restore NAME    # restore a saved layout
 ```
 
 ## Development

--- a/ptmux/cli.py
+++ b/ptmux/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Minimal CLI – exposes `ptmux list` and `ptmux attach NAME`."""
-import sys, subprocess, argparse
+"""Minimal CLI – exposes `ptmux` helper commands."""
+import subprocess, argparse
 from pathlib import Path
 
 def list_sessions() -> None:
@@ -17,18 +17,100 @@ def list_sessions() -> None:
 def attach(name: str) -> None:
     subprocess.run(["tmux", "attach-session", "-t", name])
 
+def split(direction: str, size: str | None = None) -> None:
+    args = ["tmux", "split-window"]
+    if direction in ("u", "up"):
+        args += ["-v", "-b"]
+    elif direction in ("d", "down"):
+        args += ["-v"]
+    elif direction in ("l", "left"):
+        args += ["-h", "-b"]
+    elif direction in ("r", "right"):
+        args += ["-h"]
+    else:
+        raise SystemExit("Usage: ptmux split [u|d|l|r] [size]")
+    if size:
+        args += ["-l", size]
+    subprocess.run(args, check=True)
+
+def save_session(name: str) -> None:
+    dir_ = Path.home() / ".tmux-sessions"
+    dir_.mkdir(parents=True, exist_ok=True)
+    session = subprocess.check_output(
+        ["tmux", "display-message", "-p", "#S"], text=True
+    ).strip()
+    win_idxs = subprocess.check_output(
+        ["tmux", "list-windows", "-t", session, "-F", "#{window_index}"], text=True
+    )
+    lines = []
+    for win_idx in win_idxs.strip().splitlines():
+        out = subprocess.check_output(
+            [
+                "tmux",
+                "list-panes",
+                "-t",
+                f"{session}:{win_idx}",
+                "-F",
+                f"{win_idx}\t#{pane_index}\t#{pane_current_path}",
+            ],
+            text=True,
+        )
+        lines.extend(out.strip().splitlines())
+    file = dir_ / f"{name}.tmuxsession"
+    file.write_text("\n".join(lines) + "\n")
+    print(f"Session sauvegardée dans {file}")
+
+def restore_session(name: str) -> None:
+    dir_ = Path.home() / ".tmux-sessions"
+    file = dir_ / f"{name}.tmuxsession"
+    if not file.is_file():
+        print(f"Fichier {file} introuvable.")
+        return
+    subprocess.run(["tmux", "new-session", "-d", "-s", name, "-c", "/"], check=True)
+    last_win = -1
+    pane_created = False
+    for line in file.read_text().splitlines():
+        win_idx, pane_idx, cwd = line.split("\t")
+        win_idx = int(win_idx)
+        if win_idx != last_win:
+            if last_win != -1:
+                subprocess.run(["tmux", "new-window", "-t", name, "-c", cwd], check=True)
+            else:
+                subprocess.run(["tmux", "rename-window", "-t", f"{name}:0", f"win{win_idx}"], check=True)
+                subprocess.run(["tmux", "send-keys", "-t", f"{name}:0", f"cd '{cwd}'", "C-m"], check=True)
+            last_win = win_idx
+            pane_created = True
+        if pane_created:
+            pane_created = False
+        else:
+            subprocess.run(["tmux", "split-window", "-t", f"{name}:{win_idx}", "-c", cwd], check=True)
+    print(f"Session tmux {name} restaurée. Lance : tmux attach -t {name}")
+
 def main(argv: list[str] | None = None) -> None:
     p = argparse.ArgumentParser(prog="ptmux", description="Tiny tmux helper")
     sub = p.add_subparsers(dest="cmd", required=True)
     sub.add_parser("list")
     a = sub.add_parser("attach")
     a.add_argument("name")
+    s = sub.add_parser("split")
+    s.add_argument("direction")
+    s.add_argument("size", nargs="?")
+    sv = sub.add_parser("save")
+    sv.add_argument("name")
+    rs = sub.add_parser("restore")
+    rs.add_argument("name")
     ns = p.parse_args(argv)
 
     if ns.cmd == "list":
         list_sessions()
     elif ns.cmd == "attach":
         attach(ns.name)
+    elif ns.cmd == "split":
+        split(ns.direction, ns.size)
+    elif ns.cmd == "save":
+        save_session(ns.name)
+    elif ns.cmd == "restore":
+        restore_session(ns.name)
 
 if __name__ == "__main__":
     main()

--- a/ptmux/session.py
+++ b/ptmux/session.py
@@ -55,6 +55,8 @@ class Session:
     def __getitem__(self, key):
         if isinstance(key, slice) or isinstance(key, int):
             lines = self._capture()
+            while lines and not lines[-1].strip():
+                lines.pop()
             return lines[key]
         raise TypeError("Session only supports int/slice indexing")
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -60,6 +60,11 @@ def test_session_slice_and_index(mock_subprocess):
         assert sess[-2:] == ["c", "d"]
         assert sess[1] == "b"
 
+def test_trailing_empty_lines_trimmed(mock_subprocess):
+    sess = get("trim")
+    with patch.object(sess, "_capture", return_value=["x", "y", "", "", ""]):
+        assert sess[-10:] == ["x", "y"]
+
 def test_session_invalid_index(mock_subprocess):
     sess = get("slice2")
     with pytest.raises(TypeError):


### PR DESCRIPTION
## Summary
- support splitting panes, saving sessions, and restoring sessions through CLI
- trim trailing empty lines in `Session.__getitem__`
- document new commands in README
- add test for trimmed trailing lines

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686427e590e0832e9574c3a8b337b6f9