### PR TITLE
Improve exec_wait behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ from ptmux import get   # or: from ptmux import session as get
 
 sess = get("build")
 
+# When created for the first time, the session clears its pane so you start
+# with a clean view. Commands sent with ``exec_wait`` are run exactly as if you
+# typed them yourself and the call returns once the shell prompt is back.
+
 print(sess.pwd)                       # current working dir inside the pane
 sess.exec_wait("make test")           # run & wait, combined stdout/stderr
 out = sess.exec_wait("ls -1", True)   # ⇒ {"stdout": "...", "stderr": ""}

--- a/ptmux/session.py
+++ b/ptmux/session.py
@@ -30,22 +30,29 @@ class Session:
 
     def exec_wait(self, cmd: str, split: bool = False, timeout: int = 60):
         """Run *cmd* synchronously; return str or {"stdout", "stderr"}."""
-        marker = f"__PTMUX_{uuid.uuid4().hex}__"
-        # 2>&1 to merge pipes (tmux only shows combined output)
-        self._send(f"{cmd} 2>&1; echo {marker}")
+        pre = self._capture()
+        self._send(cmd)
 
         start, last_seen = time.time(), None
         while time.time() - start < timeout:
             lines = self._capture()
-            if any(marker in l for l in lines):
-                out = "\n".join(self._strip_until(lines, marker)).rstrip()
-                return {"stdout": out, "stderr": ""} if split else out
-            # break when buffer stops changing for ~0.2 s
-            if lines == last_seen:
-                time.sleep(0.2)
-            else:
+            if lines != last_seen:
                 last_seen = lines
-        raise TimeoutError(f"{cmd!r} timed out in session {self.name!r}")
+            if lines and any(lines[-1].strip().endswith(p) for p in self.PROMPTS):
+                break
+            time.sleep(0.2)
+        else:
+            raise TimeoutError(f"{cmd!r} timed out in session {self.name!r}")
+
+        new = lines[len(pre):]
+        while new and not new[-1].strip():
+            new.pop()
+        if new and any(new[-1].strip().endswith(p) for p in self.PROMPTS):
+            new.pop()
+        if new and cmd.strip() in new[0]:
+            new = new[1:]
+        out = "\n".join(new).rstrip()
+        return {"stdout": out, "stderr": ""} if split else out
 
     def exec(self, cmd: str) -> None:
         """Fire-and-forget command (non-blocking)."""
@@ -65,6 +72,7 @@ class Session:
     def _ensure(self):
         if subprocess.run(["tmux", "has-session", "-t", self.name]).returncode:
             subprocess.run(["tmux", "new-session", "-d", "-s", self.name], check=True)
+            subprocess.run(["tmux", "send-keys", "-t", self.name, "clear", "C-m"], check=True)
 
     def _send(self, *keys: str):
         subprocess.run(["tmux", "send-keys", "-t", self.name, *keys, "C-m"], check=True)


### PR DESCRIPTION
## Summary
- wait for the prompt rather than using visible markers
- clear pane when creating a new session
- document behaviour in README
- adjust tests for the updated logic

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68642cb72bf0832e979d61967a10974a