### PR TITLE
Add _OKI_ hook to mark command completion

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,6 +1,6 @@
 import pytest
 import types
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, ANY
 
 import ptmux
 from ptmux.session import Session, get
@@ -79,8 +79,20 @@ def test_strip_until():
 
 def test_ensure_clears_on_create():
     with patch("ptmux.session.subprocess") as sp:
-        sp.run.side_effect = [types.SimpleNamespace(returncode=1), types.SimpleNamespace(returncode=0), types.SimpleNamespace(returncode=0)]
+        sp.run.side_effect = [
+            types.SimpleNamespace(returncode=1),
+            types.SimpleNamespace(returncode=0),
+            types.SimpleNamespace(returncode=0),
+            types.SimpleNamespace(returncode=0),
+        ]
         sp.check_output.return_value = ""
         Session("new")
-        sp.run.assert_any_call(["tmux", "new-session", "-d", "-s", "new"], check=True)
+        sp.run.assert_any_call([
+            "tmux",
+            "new-session",
+            "-d",
+            "-s",
+            "new",
+        ], check=True)
         sp.run.assert_any_call(["tmux", "send-keys", "-t", "new", "clear", "C-m"], check=True)
+        sp.run.assert_any_call(["tmux", "send-keys", "-t", "new", ANY, "C-m"], check=True)


### PR DESCRIPTION
## Summary
- set up `_OKI_` hook when creating new sessions
- handle `_OKI_` markers in `exec_wait` and slice operations
- adjust tests for new tmux commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643326dd24832ea8f2ccd549c23ff5