### PR TITLE
Improve session management and tests

### DIFF
--- a/ptmux/__init__.py
+++ b/ptmux/__init__.py
@@ -1,3 +1,4 @@
 """Public façade – importables are exposed here."""
 from .session import get as get               # idempotent session fetch
+from .session import clear as clear           # clear cached sessions
 from .session import Session                  # direct use if needed

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,57 @@
+import inspect
+import subprocess
+from ptmux import get, clear, Session
+
+
+def cleanup(name: str):
+    subprocess.run(["tmux", "kill-session", "-t", name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    clear(name)
+
+
+def test_cache_and_clear():
+    cleanup("t1")
+    s1 = get("t1")
+    s2 = get("t1")
+    assert s1 is s2
+    clear("t1")
+    s3 = get("t1")
+    assert s3 is not s1
+
+
+def test_clear_all():
+    cleanup("a")
+    cleanup("b")
+    a = get("a")
+    b = get("b")
+    clear()
+    assert get("a") is not a
+    assert get("b") is not b
+
+
+def test_exec_wait_output():
+    cleanup("exec")
+    sess = get("exec")
+    out = sess.exec_wait("echo hello")
+    assert out.strip() == "hello"
+
+
+def test_exec_wait_split():
+    cleanup("split")
+    sess = get("split")
+    res = sess.exec_wait("echo hi", split=True)
+    assert isinstance(res, dict)
+    assert res["stdout"].strip() == "hi"
+    assert res["stderr"] == ""
+
+
+def test_getitem_filters_markers():
+    cleanup("getitem")
+    sess = get("getitem")
+    sess.exec_wait("echo marker-test")
+    lines = sess[-5:]
+    assert all("__IKO__" not in l and not l.startswith("_OKI_") for l in lines)
+
+
+def test_exec_wait_default_timeout():
+    sig = inspect.signature(Session.exec_wait)
+    assert sig.parameters["timeout"].default == 600


### PR DESCRIPTION
## Summary
- refactor `exec_wait` logic and default timeout to 600s
- implement `clear()` helper and expose it
- filter markers in buffer access
- support root shells with `#` prompt
- add comprehensive unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68684c560ac8832e912ed52830d126ab