### PR TITLE
Improve session buffer handling and tests

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -55,3 +55,12 @@ def test_getitem_filters_markers():
 def test_exec_wait_default_timeout():
     sig = inspect.signature(Session.exec_wait)
     assert sig.parameters["timeout"].default == 600
+
+
+def test_start_marker_and_clear_history():
+    cleanup("start")
+    sess = get("start")
+    out = sess.exec_wait("echo first")
+    assert out.strip() == "first"
+    lines = sess[-5:]
+    assert "___STARTS_HERE___" not in "\n".join(lines)


### PR DESCRIPTION
## Summary
- clear tmux history after `clear` and insert a start marker
- only expose lines after the start marker when accessing session buffers
- filter out internal markers when capturing output
- add regression test for the start marker behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686853bcf9e0832e9f2dba690438c667